### PR TITLE
Split server.py for commercial products results collection

### DIFF
--- a/web/audio_handler.py
+++ b/web/audio_handler.py
@@ -7,9 +7,20 @@ def empathWav(ogg):
 def vokaturiWav(ogg):
     return convertOggToWav(ogg, '2', '44100')
 
-def convertOggToWav(ogg,ac,ar):
+def convertOggToWav(ogg, ac, ar):
     audio = AudioSegment.from_file(ogg)
+    return audio_segments_to_bytes(audio, ac, ar)
+
+def readWavFromPath(wav_file_path):
+    as_audio = AudioSegment.from_file(wav_file_path)
+    return audio_segments_to_bytes(as_audio, '2', '44100')
+
+def audio_segments_to_bytes(as_audio, ac, ar):
     buf = io.BytesIO()
-    audio.export(buf, format='wav', parameters=["-ac", ac, "-ar", ar])
+    as_audio.export(buf, format='wav', parameters=['-ac', ac, '-ar', ar])
     return buf
 
+def downSampleWav(wav_buffer):
+    print(type(wav_buffer))
+    as_audio= AudioSegment(wav_buffer.read())
+    return audio_segments_to_bytes(as_audio, '1', '11025') 

--- a/web/commercial_api.py
+++ b/web/commercial_api.py
@@ -1,0 +1,74 @@
+import audio_handler as ah
+import vokaturi as vk
+import scipy.io.wavfile as wavfile
+import wave
+import io
+import requests
+import os
+import base64
+import json
+import copy
+
+API = {'empath':'https://api.webempath.net/v2/analyzeWav',
+        'deepaffect':'https://proxy.api.deepaffects.com/audio/generic/api/v2/sync/recognise_emotion'}
+
+key = {'empath':'-DfigHIMK3a9HBwozQONFbp3DLdLCNtBlrSdFJ5UbhY',
+        'deepaffect':'QUV3GNwPB7EPk5TWJQUjospamvusFGK3'}
+
+
+# params: audio        -- bytes : sample rate 44100hz and 2 channel
+#         index        -- the index coule be a random string or an integer
+#         audio_format -- 'ogg'/'wav' 
+def emotion_detect(audio, index, audio_format):
+
+    # We have to deep copy for each API, in the sense that they are should not be misused
+    input_vokaturi = None
+    input_empath = None
+    input_deep_affect = None
+
+    if audio_format == 'ogg': 
+        input_vokaturi = ah.vokaturiWav(io.BytesIO(audio))
+        input_empath = ah.empathWav(io.BytesIO(audio))
+        input_deep_affect = ah.vokaturiWav(io.BytesIO(audio)).read()
+    elif audio_format == 'wav':
+        input_vokaturi = copy.deepcopy(audio)
+        input_empath = ah.downSampleWav(copy.deepcopy(audio))
+        input_deep_affect = copy.deepcopy(audio).read()
+    else:
+        print("Unknow format:{}, only ogg/was are supported".format(audio_format))
+        return ""
+        
+    result = {'index' : index}
+   
+    try:
+        # Vokaturi AR 44100 AC 2
+        ar, vk_sample = wavfile.read(input_vokaturi)
+        result['vokaturi'] = vk.detect(vk_sample, ar)
+    except BaseException as error:
+        result['vokaturi'] = 'No Result'
+        print('Vokaturi error with message:{}'.format(error))
+
+    try:
+        # Empath AR 11025 AC 1
+        response = requests.post(API['empath'], files = {"wav" : input_empath}, params = {'apikey' : key['empath']})
+        result['empath'] = json.loads(response.text)
+    except BaseException as error:
+        result['empath'] = 'No Result'
+        print('Empath error with message:{}'.format(error))
+   
+    try:
+        # Deep Affect AR 44100 AC 2 
+        req = {'encoding':'WAV', 'sample_rate':'44100','language':'en-US', 'content':str(input_deep_affect)}
+        response = requests.post(API['deepaffect'],
+        headers = {'Content-Type':'application/json'},
+        data = json.dumps(req),
+        params = {'apikey' : key['deepaffect']})
+        text = response.text
+        print("Respones from Deep Affect:{}".format(text))
+        result['deepaffect'] = json.loads(text)
+    except BaseException as error:
+        result['deepaffect'] = 'No Result'
+        print('An exception occurred: {}'.format(error))
+    return json.dumps(result)
+
+

--- a/web/server.py
+++ b/web/server.py
@@ -1,22 +1,9 @@
 from flask import Flask,send_from_directory, render_template,request
 import audio_handler as ah
-import vokaturi as vk
-import scipy.io.wavfile as wavfile
-import wave
-import io
-import requests
-import os
-import base64
-import json
-import copy
+import commercial_api as ca
+import uuid
 
 app = Flask(__name__, template_folder='static')
-
-API = {'empath':'https://api.webempath.net/v2/analyzeWav',
-        'deepaffect':'https://proxy.api.deepaffects.com/audio/generic/api/v2/sync/recognise_emotion'}
-
-key = {'empath':'-DfigHIMK3a9HBwozQONFbp3DLdLCNtBlrSdFJ5UbhY',
-        'deepaffect':'QUV3GNwPB7EPk5TWJQUjospamvusFGK3'}
 
 @app.route('/')
 def index():
@@ -30,39 +17,8 @@ def videos(path):
 def ad():
     ogg = request.files['audio']
     buffs = ogg.read()
-    result = {}
-    print('================'+ str(type(ogg))) 
-    try:
-        # Vokaturi
-        sample_ar44100_ac2 = ah.vokaturiWav(io.BytesIO(buffs))
-        (ar, vk_sample) = wavfile.read(sample_ar44100_ac2)
-        result['vokaturi'] = vk.detect(vk_sample, ar)
-    except BaseException as error:
-        result['vokaturi'] = 'No Result'
-        print('Vokaturi error with message:{}'.format(error))
-
-    try:
-        # Empath
-        em_sample = ah.empathWav(io.BytesIO(buffs))
-        response = requests.post(API['empath'], files={"wav":em_sample}, params={'apikey':key['empath']})
-        result['empath'] = json.loads(response.text)
-    except BaseException as error:
-        result['empath'] = 'No Result'
-        print('Empath error with message:{}'.format(error))
-   
-    try:
-        # Deep Affect
-        sample_ar44100_ac2 = ah.vokaturiWav(io.BytesIO(buffs))
-        req = {'encoding':'WAV', 'sample_rate':'44100','language':'en-US', 'content':str(sample_ar44100_ac2.read())}
-        response = requests.post(API['deepaffect'],
-        headers={'Content-Type':'application/json'},
-        data=json.dumps(req),
-        params={'apikey':key['deepaffect']})
-        result['deepaffect'] = json.loads(response.text)
-    except BaseException as error:
-        result['deepaffect'] = 'No Result'
-        print('An exception occurred: {}'.format(error))
-    return json.dumps(result)
+    return ca.emotion_detect(buffs, str(uuid.uuid4()), 'ogg')
+    
 
 if __name__ == '__main__':
     #app.run(debug=False, host='0.0.0.0', threaded=True)


### PR DESCRIPTION
Get commercial emotion detection result by following:

```python
import commercial_api as ca
import audio_handler as ah

wav = ah.readWavFromPath('./test data set')
index = "UUID" # Data index 
audio_format = 'wav' # ogg also supported

print(ca.emotion_detect(wav, index, audio_format))

```
There are 2 more things need to do:
1.  Read API key from file, prepare backup keys for `Empath` and `DeepAffects`.
2.  Invoke the API above in `.ipynb` or other `.py` script, output well orgnized results.

